### PR TITLE
Rename LOWER_THAN to STRICTLY_LESS_THAN

### DIFF
--- a/src/main/java/com/accelad/acctive/sim/kernel/core/evaluator/diff/DiffFuncEvaluator.java
+++ b/src/main/java/com/accelad/acctive/sim/kernel/core/evaluator/diff/DiffFuncEvaluator.java
@@ -164,8 +164,8 @@ public class DiffFuncEvaluator<X extends Field<X>>
         switch (functionKind) {
         case GREATER_THAN:
             return new GreaterThanFunction<>(factory, args.get(0), args.get(1));
-        case LOWER_THAN:
-            return new LowerThanFunction<>(factory, args.get(0), args.get(1));
+        case STRICTLY_LESS_THAN:
+            return new StrictlyLessThanFunction<>(factory, args.get(0), args.get(1));
         case BETWEEN:
             return new BetweenFunction<>(factory, args.get(0), args.get(1), args.get(2));
         case OUTSIDE:
@@ -245,7 +245,7 @@ public class DiffFuncEvaluator<X extends Field<X>>
             List<DifferentialFunction<X>> args) {
         DifferentialFunction<X> x = args.get(0);
         DifferentialFunction<X> x0 = args.get(1);
-        DifferentialFunction<X> lowPart = new LowerThanFunction<>(mathFactory, x,
+        DifferentialFunction<X> lowPart = new StrictlyLessThanFunction<>(mathFactory, x,
                 mathFactory.one().minus(x0)).mul(
                 x.plus(x0).mul(mathFactory.exp(mathFactory.one().minus(x0))));
         DifferentialFunction<X> middlePart = new RestrictedDomainFunction<>(mathFactory, x,

--- a/src/main/java/com/accelad/acctive/sim/kernel/core/evaluator/diff/FunctionKind.java
+++ b/src/main/java/com/accelad/acctive/sim/kernel/core/evaluator/diff/FunctionKind.java
@@ -6,7 +6,7 @@ import com.fathzer.soft.javaluator.Function;
 
 enum FunctionKind {
     GREATER_THAN(new Function("greaterthan", 2)),
-    LOWER_THAN(new Function("lowerthan", 2)),
+    STRICTLY_LESS_THAN(new Function("lowerthan", 2)),
     BETWEEN(new Function("between", 3)),
     OUTSIDE(new Function("outside", 3)),
     LATCH(new Function("latch", 3)),

--- a/src/main/java/com/accelad/acctive/sim/kernel/core/evaluator/diff/StrictlyLessThanFunction.java
+++ b/src/main/java/com/accelad/acctive/sim/kernel/core/evaluator/diff/StrictlyLessThanFunction.java
@@ -8,12 +8,12 @@ import com.accelad.math.nilgiri.autodiff.AbstractBinaryFunction;
 import com.accelad.math.nilgiri.autodiff.DifferentialFunction;
 import com.accelad.math.nilgiri.autodiff.Variable;
 
-class LowerThanFunction<X extends Field<X>>
+class StrictlyLessThanFunction<X extends Field<X>>
         extends AbstractBinaryFunction<X> {
 
     private final MathFactory<X> DFFactory;
 
-    LowerThanFunction(MathFactory<X> DFFactory, DifferentialFunction<X> i_v1,
+    StrictlyLessThanFunction(MathFactory<X> DFFactory, DifferentialFunction<X> i_v1,
             DifferentialFunction<X> i_v2) {
         super(i_v1, i_v2);
         this.DFFactory = DFFactory;
@@ -37,7 +37,7 @@ class LowerThanFunction<X extends Field<X>>
 
     @Override
     public String toString() {
-        return "LowerThan";
+        return "StrictlyLessThan";
     }
 
     @Override

--- a/src/test/java/com/accelad/acctive/sim/kernel/core/evaluator/diff/StrictlyLessThanFunctionTest.java
+++ b/src/test/java/com/accelad/acctive/sim/kernel/core/evaluator/diff/StrictlyLessThanFunctionTest.java
@@ -11,7 +11,7 @@ import com.accelad.math.nilgiri.DoubleReal;
 import com.accelad.math.nilgiri.autodiff.DifferentialFunction;
 import com.accelad.math.nilgiri.autodiff.Variable;
 
-public class LowerThanFunctionTest {
+public class StrictlyLessThanFunctionTest {
 
     @Test
     public void testDiff() {
@@ -19,7 +19,7 @@ public class LowerThanFunctionTest {
         DifferentialFunction<DoubleReal> f1 = mock(DifferentialFunction.class);
         DifferentialFunction<DoubleReal> f2 = mock(DifferentialFunction.class);
         Variable<DoubleReal> v = mock(Variable.class);
-        LowerThanFunction<DoubleReal> func = new LowerThanFunction<>(factory, f1, f2);
+        StrictlyLessThanFunction<DoubleReal> func = new StrictlyLessThanFunction<>(factory, f1, f2);
 
         DoubleReal result = func.diff(v).getValue();
         DoubleReal expected = factory.zero().getValue();


### PR DESCRIPTION
This naming aims to differentiate strict inequality provided by "less than" operator (<) from large inequality of provided to "greater than" operator (>=)